### PR TITLE
status = resolved

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [dev-packages]
 
 [packages]
-ddtrace = "*"
+ddtrace = ">=0.21.0"
 gevent = "*"
 flask = "*"
 gunicorn = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9173fac3ce95d27c699e97d4d89c5433cc1738e10c6a4fbbb65c8c6c94249ef9"
+            "sha256": "4e9b05cf35e95bddd2efb83f4d03c9b76406c07151de68b57633871eb1472770"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,23 +21,23 @@
                 "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==7.0"
         },
         "ddtrace": {
             "hashes": [
-                "sha256:2f52672ce3aeff1d25b74166b7ba1881e62804ace3c91f8e268661ab4ef8aab0"
+                "sha256:17d58dbbd340902f90e7f6073abaca6b2259fcc0faf206b0e113e4f62bf7dfee"
             ],
             "index": "pypi",
-            "version": "==0.20.4"
+            "version": "==0.21.0"
         },
         "flask": {
             "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
+                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.1.1"
         },
         "gevent": {
             "hashes": [
@@ -106,50 +106,50 @@
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
                 "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
-            "version": "==2.10"
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
-            "version": "==1.1.0"
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
+            "version": "==1.1.1"
         },
         "msgpack-python": {
             "hashes": [
@@ -159,11 +159,10 @@
         },
         "python-json-logger": {
             "hashes": [
-                "sha256:3e000053837500f9eb28d6228d7cb99fabfc1874d34b40c08289207292abaf2e",
-                "sha256:cf2caaf34bd2eff394915b6242de4d0245de79971712439380ece6f149748cde"
+                "sha256:b7a31162f2a01965a5efb94453ce69230ed208468b0bbc7fdfc56e6d8df2e281"
             ],
             "index": "pypi",
-            "version": "==0.1.10"
+            "version": "==0.1.11"
         },
         "six": {
             "hashes": [
@@ -183,16 +182,17 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:00d32beac38fcd48d329566f80d39f10ec2ed994efbecfb8dd4b320062d05902",
+                "sha256:0a24d43be6a7dce81bae05292356176d6c46d63e42a0dd3f9504b210a9cfaa43"
             ],
-            "version": "==0.14.1"
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
+            "version": "==0.15.6"
         },
         "wrapt": {
             "hashes": [
-                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
-            "version": "==1.11.1"
+            "version": "==1.11.2"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ The log statements in the startup routine describe when the server has started l
 
 1. Either python module imports have a bug or the ddtrace patcher has a bug that leads to an import deadlock given this example architecture.
 1. Looking for feedback on how to fix this issue.
-1. [Issue opened with vendor](https://github.com/DataDog/dd-trace-py/issues/827) - STATUS = UNRESOLVED
+1. [Issue opened with vendor](https://github.com/DataDog/dd-trace-py/issues/827) - STATUS = RESOLVED
+
+# Resolution
+
+1. Use a version of ddtrace >= 0.21.0
 
 ### If you are interested in running the ddagent sidecar at the same time:
 


### PR DESCRIPTION
resolution was offered back in April when I was on vacation:

https://github.com/DataDog/dd-trace-py/issues/827#issuecomment-488005734

verified:

```text
00:~/github.com/josephcopenhaver/srft $ docker-compose down -v ; docker-compose build >/dev/null 2>/dev/null && docker-compose up
Removing network srft_default
WARNING: Network srft_default not found.
Removing volume srft_dependencies
WARNING: Volume srft_dependencies not found.
Creating network "srft_default" with the default driver
Creating volume "srft_dependencies" with default driver
Creating srft_dependencies_1 ... done
Creating srft-test           ... done
Attaching to srft_dependencies_1, srft-test
srft_dependencies_1 exited with code 0
srft-test       | [s6-init] making user provided files available at /var/run/s6/etc...exited 0.
srft-test       | [s6-init] ensuring user provided files have correct perms...exited 0.
srft-test       | [fix-attrs.d] applying ownership & permissions fixes...
srft-test       | [fix-attrs.d] done.
srft-test       | [cont-init.d] executing container initialization scripts...
srft-test       | [cont-init.d] done.
srft-test       | [services.d] starting services
srft-test       | [services.d] done.
srft-test       | {"message": "Starting gunicorn 19.9.0", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.538837Z"}
srft-test       | {"message": "Listening at: http://0.0.0.0:80 (166)", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.539370Z"}
srft-test       | {"message": "Using worker: gevent", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.539553Z"}
srft-test       | {"message": "Booting worker with pid: 194", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.543292Z"}
srft-test       | {"message": "Booting worker with pid: 195", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.641697Z"}
srft-test       | {"message": "Booting worker with pid: 196", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.671181Z"}
srft-test       | {"message": "Booting worker with pid: 197", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.723212Z"}
srft-test       | {"message": "Booting worker with pid: 198", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.733604Z"}
srft-test       | {"message": "Booting worker with pid: 199", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.744633Z"}
srft-test       | {"message": "Booting worker with pid: 200", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.802652Z"}
srft-test       | {"message": "Booting worker with pid: 201", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.817231Z"}
srft-test       | {"message": "Booting worker with pid: 202", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.851737Z"}
srft-test       | {"message": "Booting worker with pid: 203", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.868890Z"}
srft-test       | {"message": "Booting worker with pid: 204", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:03.960002Z"}
srft-test       | {"message": "Booting worker with pid: 205", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.024616Z"}
srft-test       | {"message": "Booting worker with pid: 206", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.050534Z"}
srft-test       | {"message": "Booting worker with pid: 207", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.058886Z"}
srft-test       | {"message": "Booting worker with pid: 208", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.154797Z"}
srft-test       | {"message": "Booting worker with pid: 209", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.218453Z"}
srft-test       | {"message": "Booting worker with pid: 210", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.294689Z"}
srft-test       | {"message": "Booting worker with pid: 211", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.310936Z"}
srft-test       | {"message": "Booting worker with pid: 212", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.367165Z"}
srft-test       | {"message": "Booting worker with pid: 213", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.420005Z"}
srft-test       | {"message": "Booting worker with pid: 214", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.498846Z"}
srft-test       | {"message": "Booting worker with pid: 215", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.583093Z"}
srft-test       | {"message": "Booting worker with pid: 216", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.601639Z"}
srft-test       | {"message": "Booting worker with pid: 217", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.680577Z"}
srft-test       | {"message": "Booting worker with pid: 218", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.724438Z"}
srft-test       | {"message": "Booting worker with pid: 219", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.786499Z"}
srft-test       | {"message": "Booting worker with pid: 220", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.887847Z"}
srft-test       | {"message": "Booting worker with pid: 221", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.905683Z"}
srft-test       | {"message": "Booting worker with pid: 222", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.965617Z"}
srft-test       | {"message": "Booting worker with pid: 223", "logger": "wsgi", "level": "info", "timestamp": "2019-09-06T15:24:04.973227Z"}
^CGracefully stopping... (press Ctrl+C again to force)
Stopping srft-test           ... done
00:~/github.com/josephcopenhaver/srft $
```

and while it was running:

```text
00:~ $ curl -Nvs http://localhost:5000/healthcheck
*   Trying ::1:5000...
* TCP_NODELAY set
* Connected to localhost (::1) port 5000 (#0)
> GET /healthcheck HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.65.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: gunicorn/19.9.0
< Date: Fri, 06 Sep 2019 15:25:41 GMT
< Connection: keep-alive
< Content-Type: text/html; charset=utf-8
< Content-Length: 2
<
ok* Connection #0 to host localhost left intact
00:~ $
```